### PR TITLE
feat: 스테이지 페이지 기능 구현 (서버 데이터 전역 상태로 설정)

### DIFF
--- a/swype-client/src/apis/userInfo.ts
+++ b/swype-client/src/apis/userInfo.ts
@@ -1,21 +1,7 @@
 import axios from 'axios';
 import { BASE_URL } from '../share/utils/OAuth';
 import { getCookie } from '../cookie';
-
-interface CharacterInfo {
-  id: number;
-  name: string;
-  maxLevel: number;
-}
-
-interface UserInfo {
-  character: CharacterInfo;
-  level: number;
-  environment: string;
-  backgroundImage: string;
-  characterImage: string;
-  userPoint: number;
-}
+import { UserInfo } from '../model/userInfoType';
 
 const token = getCookie('Authorization');
 

--- a/swype-client/src/apis/video/getVideoWatched.ts
+++ b/swype-client/src/apis/video/getVideoWatched.ts
@@ -15,13 +15,9 @@ export const getVideoWatched = (): Promise<{ isWatched: boolean }> => {
         },
       }
     )
-    .then(res => {
-      const isWatchedData = res.data.data;
-      console.log('isWatched data:', isWatchedData); // 서버에서 반환된 isWatched 데이터를 출력합니다.
-      return isWatchedData;
-    })
+    .then(res => res.data.data)
     .catch(error => {
-      console.error('error:', error.response.data); // 서버에서 반환된 에러 메시지를 출력합니다.
+      console.error('error:', error);
       throw error;
     });
 };

--- a/swype-client/src/components/FeatureButtons.tsx
+++ b/swype-client/src/components/FeatureButtons.tsx
@@ -5,8 +5,12 @@ import { useNavigate } from 'react-router-dom';
 import { getVideoWatched } from '../apis/video/getVideoWatched';
 import { useQuery } from '@tanstack/react-query';
 import { showToast } from '../share/utils/Toast';
+import { userData } from '../share/recoil/userAtom';
+import { useRecoilValue } from 'recoil';
 
 const FeatureButtons = () => {
+  const userInfo = useRecoilValue(userData);
+
   const navigate = useNavigate();
   const { data } = useQuery({
     queryKey: ['getVideoWatched'],
@@ -17,7 +21,7 @@ const FeatureButtons = () => {
     if (data?.isWatched) {
       navigate('/movie');
     } else {
-      showToast('warning', '오늘 영상을 이미 시정하였어요. 12시 이후에 다시 만나요!');
+      showToast('warning', '오늘 영상을 이미 시정하였어요. 00시 이후에 다시 만나요!');
     }
   };
 
@@ -25,16 +29,14 @@ const FeatureButtons = () => {
     <Wrapper>
       <Info>
         <LevelBox>
-          <span>Lv.1</span>
+          <span>Lv. {userInfo?.level}</span>
         </LevelBox>
         <NameBox>
-          <span>폴라</span>
+          <span>{userInfo?.character.name}</span>
         </NameBox>
       </Info>
       <ButtonContainer>
-
         <QuizBox onClick={() => navigate('/quiz')}>
-
           <QuizImg src={Quiz}></QuizImg>
           <QuizText>
             남은 횟수 <br />
@@ -43,7 +45,6 @@ const FeatureButtons = () => {
         </QuizBox>
 
         <MovieBox onClick={handleVideoClick}>
-
           <MovieImg src={Video}></MovieImg>
           <MovieText>영상 시청</MovieText>
         </MovieBox>

--- a/swype-client/src/model/userInfoType.ts
+++ b/swype-client/src/model/userInfoType.ts
@@ -5,10 +5,10 @@ export interface CharacterInfo {
 }
 
 export interface UserInfo {
-  character?: CharacterInfo;
-  level?: number;
-  environment?: string;
-  backgroundImage?: string;
-  characterImage?: string;
-  userPoint?: number;
+  character: CharacterInfo;
+  level: number;
+  environment: string;
+  backgroundImage: string;
+  characterImage: string;
+  userPoint: number;
 }

--- a/swype-client/src/pages/PollutedStage.tsx
+++ b/swype-client/src/pages/PollutedStage.tsx
@@ -7,7 +7,7 @@ import TrashCan from '../components/Trash-related/TrashCan';
 import { useEffect, useState } from 'react';
 import { DragDropContext, DropResult, Droppable } from 'react-beautiful-dnd';
 
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { draggableItemsState, initialTrashItemsState } from '../share/recoil/dndAtoms';
 import Point from '../components/Point';
 import { useNavigate } from 'react-router-dom';
@@ -15,8 +15,9 @@ import TrashModal from '../components/Modal/TrashModal';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { trashPoint } from '../apis/trashPoint';
 import { getTrashImg } from '../apis/trashImg';
-import { getUserInfo } from '../apis/userInfo';
+
 import Polluted_Water from '../assets/trash/Polluted_Water.png';
+import { userData } from '../share/recoil/userAtom';
 
 interface TrashImgData {
   backgroundImage: string;
@@ -28,21 +29,6 @@ interface TrashPointData {
   afterPoint: number;
 }
 
-interface CharacterInfo {
-  id: number;
-  name: string;
-  maxLevel: number;
-}
-
-interface UserInfo {
-  character: CharacterInfo;
-  level: number;
-  environment: string;
-  backgroundImage: string;
-  characterImage: string;
-  userPoint: number;
-}
-
 const PollutedStage = () => {
   const [trashItems, setTrashItems] = useRecoilState(draggableItemsState);
   const [trashCanVisible, setTrashCanVisible] = useState(false);
@@ -50,16 +36,12 @@ const PollutedStage = () => {
   const [addPoint, setAddPoint] = useState(0);
   const [afterPoint, setAfterPoint] = useState(0);
 
+  const userInfo = useRecoilValue(userData);
+
   // 쓰레기 배경, 동물 받아오기
   const { data: trashStatusImg } = useQuery<TrashImgData>({
     queryKey: ['trashStatusImg'],
     queryFn: getTrashImg,
-  });
-
-  // 레벨, 동물 이름 받아오기
-  const { data: userInfo } = useQuery<UserInfo>({
-    queryKey: ['userInfo'],
-    queryFn: getUserInfo,
   });
 
   const mutation = useMutation<TrashPointData>({
@@ -126,10 +108,10 @@ const PollutedStage = () => {
         <CharacterImageWrapper>
           <Info>
             <LevelBox>
-              <span>{userInfo?.level}</span>
+              <span>Lv. {userInfo?.level}</span>
             </LevelBox>
             <NameBox>
-              <span>{userInfo?.character.name}</span>
+              <span>{userInfo?.character?.name}</span>
             </NameBox>
           </Info>
           <img

--- a/swype-client/src/pages/Splash.tsx
+++ b/swype-client/src/pages/Splash.tsx
@@ -27,9 +27,6 @@ const Splash = () => {
 const SplashGIF = styled.img`
   width: 100%;
   height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
 `;
 
 const fadeOut = keyframes`

--- a/swype-client/src/pages/Stage.tsx
+++ b/swype-client/src/pages/Stage.tsx
@@ -1,7 +1,5 @@
 import { Container } from '../share/utils/GlobalStyle';
 import FeatureButtons from '../components/FeatureButtons';
-import Frozen_Land from '../assets/Frozen_Land.png';
-import Iceberg_Pola from '../assets/Iceberg_Pola.png';
 import Header from '../components/common/Header';
 import styled from 'styled-components';
 import Store from '../assets/Store.png';
@@ -12,10 +10,26 @@ import { useEffect, useState } from 'react';
 import Point from '../components/Point';
 import { trashStatusCheck } from '../apis/trashStatusCheck';
 import { showToast } from '../share/utils/Toast';
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfo } from '../apis/userInfo';
+import { useSetRecoilState } from 'recoil';
+import { userData } from '../share/recoil/userAtom';
 
 const Stage = () => {
   const [isClean, setIsClean] = useState(false);
   const navigate = useNavigate();
+  const setUserData = useSetRecoilState(userData);
+
+  const { data: userInfo } = useQuery({
+    queryKey: ['userInfo'],
+    queryFn: getUserInfo,
+  });
+
+  useEffect(() => {
+    if (userInfo) {
+      setUserData(userInfo);
+    }
+  }, [userInfo, setUserData]);
 
   useEffect(() => {
     // cleanData 함수가 서버에서 청소 상태를 받아와서 isClean 상태를 설정함
@@ -35,7 +49,7 @@ const Stage = () => {
     if (!isClean) {
       navigate('/polluted');
     } else {
-      showToast('error', '쓰레기 줍기는 이미 완료 되었습니다. 12시 이후에 다시 만나요!');
+      showToast('warning', '오늘의 쓰레기를 다 치웠어요. 00시 이후에 다시 만나요!');
     }
   };
 
@@ -46,7 +60,7 @@ const Stage = () => {
   return (
     <Container>
       <Header rightChild={<Point />} />
-      <Wrapper>
+      <Wrapper backgroundImage={userInfo?.backgroundImage}>
         <Out>
           <StoreButton onClick={goStorePage}>
             <img src={Store} />
@@ -58,7 +72,7 @@ const Stage = () => {
           </TrashButton>
         </Out>
         <CharacterBox>
-          <CharacterImage src={Iceberg_Pola} />
+          <CharacterImage src={userInfo?.characterImage} />
         </CharacterBox>
         <InfoBox>
           <FeatureButtons />
@@ -70,13 +84,12 @@ const Stage = () => {
 
 export default Stage;
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ backgroundImage?: string }>`
   position: relative;
   background-color: #E1F3F4;
   width: 100%;
   height: 100vh;
-  background-image: url(${Frozen_Land});
-  background-repeat: no-repeat;
+  background-image: url(${props => props.backgroundImage});  background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
   display: flex;

--- a/swype-client/src/share/recoil/userAtom.tsx
+++ b/swype-client/src/share/recoil/userAtom.tsx
@@ -1,21 +1,7 @@
 import { atom } from 'recoil';
+import { UserInfo } from '../../model/userInfoType';
 
-interface CharacterInfoProps {
-  id?: number;
-  name?: string;
-  maxLevel?: number;
-}
-
-interface UserInfoProps {
-  character?: CharacterInfoProps;
-  level?: number;
-  environment?: string;
-  backgroundImage?: string;
-  characterImage?: string;
-  userPoint?: number;
-}
-
-export const userData = atom<UserInfoProps | null>({
+export const userData = atom<UserInfo | null>({
   key: 'userData',
   default: null,
 });


### PR DESCRIPTION
- 스테이지 페이지 기능 구현 (서버 데이터 적용)
- 서버 데이터 전역 상태로 설정 (recoil)
- featureButtons, Polluted 페이지 전역 데이터 적용
- 스플레쉬 화면 전체 크기 차지하는 부분 Container 사이즈로 수정

스테이지 페이지: 배경, 동물 이미지
오염된 페이지: 레벨, 이름
featureButtons 컴포넌트: 레벨, 이름

적용하였습니다.

지금 계정 삭제가 안 되는 상황이라 삭제 후 로그인 -> 캐릭터 선택 플로우 거치고 나서 데이터가 잘 들어오는 지 확인할 수 있을 것 같습니다.