### PR TITLE
feat: 포인트, 남은 생명 데이터 적용, Toast, 영상 코드 일부 수정

### DIFF
--- a/swype-client/src/apis/remainContents.ts
+++ b/swype-client/src/apis/remainContents.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { BASE_URL } from '../share/utils/OAuth';
+import { getCookie } from '../cookie';
+import { RemainData } from '../model/remainDataType';
+
+const token = getCookie('Authorization');
+
+export const remainContents = (): Promise<RemainData> => {
+  return axios
+    .get<{ data: RemainData }>(`${BASE_URL}/contents/remaining`, {
+      headers: {
+        Authorization: `${token}`,
+      },
+    })
+    .then(res => {
+      console.log('API response:', res.data.data); // 응답 데이터 로깅
+      return res.data.data;
+    })
+    .catch(error => {
+      console.log('err', error);
+      throw error;
+    });
+};

--- a/swype-client/src/apis/userInfo.ts
+++ b/swype-client/src/apis/userInfo.ts
@@ -14,7 +14,7 @@ export const getUserInfo = (): Promise<UserInfo> => {
     })
     .then(res => res.data.data)
     .catch(error => {
-      console.error('err:', error);
+      console.error('User err:', error);
       throw error;
     });
 };

--- a/swype-client/src/apis/video/getVideoWatched.ts
+++ b/swype-client/src/apis/video/getVideoWatched.ts
@@ -17,7 +17,7 @@ export const getVideoWatched = (): Promise<{ isWatched: boolean }> => {
     )
     .then(res => res.data.data)
     .catch(error => {
-      console.error('error:', error);
+      console.error('영상 error:', error);
       throw error;
     });
 };

--- a/swype-client/src/components/FeatureButtons.tsx
+++ b/swype-client/src/components/FeatureButtons.tsx
@@ -7,9 +7,11 @@ import { useQuery } from '@tanstack/react-query';
 import { showToast } from '../share/utils/Toast';
 import { userData } from '../share/recoil/userAtom';
 import { useRecoilValue } from 'recoil';
+import { remainData } from '../share/recoil/remainAtom';
 
 const FeatureButtons = () => {
   const userInfo = useRecoilValue(userData);
+  const remainQuiz = useRecoilValue(remainData);
 
   const navigate = useNavigate();
   const { data } = useQuery({
@@ -18,10 +20,13 @@ const FeatureButtons = () => {
   });
 
   const handleVideoClick = () => {
-    if (data?.isWatched) {
-      navigate('/movie');
+    if (
+      typeof data === 'string' &&
+      (data as string).includes('오늘의 영상 횟수가 소진되었습니다.')
+    ) {
+      showToast('warning', '오늘 영상을 이미 시청하였어요.', '00시 이후에 다시 만나요!');
     } else {
-      showToast('warning', '오늘 영상을 이미 시정하였어요. 00시 이후에 다시 만나요!');
+      navigate('/movie');
     }
   };
 
@@ -40,7 +45,7 @@ const FeatureButtons = () => {
           <QuizImg src={Quiz}></QuizImg>
           <QuizText>
             남은 횟수 <br />
-            3/3
+            {remainQuiz.remainQuestion}/3
           </QuizText>
         </QuizBox>
 

--- a/swype-client/src/components/Point.tsx
+++ b/swype-client/src/components/Point.tsx
@@ -1,5 +1,7 @@
 import StorePoint from '../assets/StorePoint.png';
 import styled from 'styled-components';
+import { userData } from '../share/recoil/userAtom';
+import { useRecoilValue } from 'recoil';
 
 const Item = styled.div`
   display: flex;
@@ -18,6 +20,8 @@ img{
 `;
 
 const Point = () => {
+  const userInfo = useRecoilValue(userData);
+
   return (
     <>
       <Item>
@@ -25,7 +29,7 @@ const Point = () => {
           src={StorePoint}
           alt='포인트'
         />
-        <span>30</span>
+        <span>{userInfo?.userPoint}</span>
       </Item>
     </>
   );

--- a/swype-client/src/components/QuizLife.tsx
+++ b/swype-client/src/components/QuizLife.tsx
@@ -1,5 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
 import Quiz_Life from '../assets/Quiz_Life.png';
 import styled from 'styled-components';
+import { remainContents } from '../apis/remainContents';
+import { useSetRecoilState } from 'recoil';
+import { remainData } from '../share/recoil/remainAtom';
+import { useEffect } from 'react';
 
 const Item = styled.div`
   display: flex;
@@ -18,6 +23,19 @@ const Item = styled.div`
 `;
 
 const QuizLife = () => {
+  const setRemainData = useSetRecoilState(remainData);
+
+  const { data } = useQuery({
+    queryKey: ['quiz'],
+    queryFn: remainContents,
+  });
+
+  useEffect(() => {
+    if (data) {
+      setRemainData(data);
+    }
+  }, [data, setRemainData]);
+
   return (
     <>
       <Item>
@@ -25,7 +43,7 @@ const QuizLife = () => {
           src={Quiz_Life}
           alt='퀴즈 생명'
         />
-        <span>0/3</span>
+        <span>{data?.remainQuestion}/3</span>
       </Item>
     </>
   );

--- a/swype-client/src/model/remainDataType.ts
+++ b/swype-client/src/model/remainDataType.ts
@@ -1,0 +1,4 @@
+export interface RemainData {
+  remainQuestion: number;
+  remainVideo: number;
+}

--- a/swype-client/src/pages/Movie.tsx
+++ b/swype-client/src/pages/Movie.tsx
@@ -20,8 +20,7 @@ export default function Movie() {
   const mutation = useMutation({
     mutationFn: getVideoWatched,
     onSuccess: () => {
-      navigate(`/`);
-      console.log('hi');
+      navigate(`/stage`);
     },
   });
 

--- a/swype-client/src/pages/Stage.tsx
+++ b/swype-client/src/pages/Stage.tsx
@@ -32,7 +32,6 @@ const Stage = () => {
   }, [userInfo, setUserData]);
 
   useEffect(() => {
-    // cleanData 함수가 서버에서 청소 상태를 받아와서 isClean 상태를 설정함
     const cleanData = async () => {
       try {
         const status = await trashStatusCheck();
@@ -49,7 +48,7 @@ const Stage = () => {
     if (!isClean) {
       navigate('/polluted');
     } else {
-      showToast('warning', '오늘의 쓰레기를 다 치웠어요. 00시 이후에 다시 만나요!');
+      showToast('warning', '오늘의 쓰레기를 다 치웠어요.', '00시 이후에 다시 만나요!');
     }
   };
 
@@ -89,7 +88,8 @@ const Wrapper = styled.div<{ backgroundImage?: string }>`
   background-color: #E1F3F4;
   width: 100%;
   height: 100vh;
-  background-image: url(${props => props.backgroundImage});  background-repeat: no-repeat;
+  background-image: url(${props => props.backgroundImage});  
+  background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
   display: flex;

--- a/swype-client/src/share/recoil/remainAtom.tsx
+++ b/swype-client/src/share/recoil/remainAtom.tsx
@@ -1,0 +1,10 @@
+import { atom } from 'recoil';
+import { RemainData } from '../../model/remainDataType';
+
+export const remainData = atom<RemainData>({
+  key: 'remainData',
+  default: {
+    remainQuestion: 0,
+    remainVideo: 0,
+  },
+});

--- a/swype-client/src/share/utils/Toast.ts
+++ b/swype-client/src/share/utils/Toast.ts
@@ -1,30 +1,55 @@
 import Swal, { SweetAlertIcon } from 'sweetalert2';
+import styled from 'styled-components';
+import ReactDOMServer from 'react-dom/server';
+import React from 'react';
 
-// 토스트 알림 css 옵션
+const StyledToast = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  
+  color: #959595;
+  line-height: 30px;
+  
+`;
+
+const toastHtml = (firstLine: string, secondLine: string) => {
+  return ReactDOMServer.renderToString(
+    React.createElement(
+      StyledToast,
+      null,
+      React.createElement('span', null, firstLine),
+      React.createElement('span', null, secondLine)
+    )
+  );
+};
+
+// SweetAlert2 토스트 알림 옵션
 export const Toast = Swal.mixin({
   toast: true,
   position: 'center',
   showConfirmButton: false,
-  timer: 2000,
+  timer: 1200,
   timerProgressBar: false,
-  padding: '10px',
-  color: '#959595',
   didOpen: toast => {
     toast.onmouseenter = Swal.stopTimer;
     toast.onmouseleave = Swal.resumeTimer;
   },
 });
 
-// 토스트 알림 함수 - showToast
-export const showToast = (icon: SweetAlertIcon, title: string) => {
-  Toast.fire({ icon, title });
+// 커스텀 토스트 알림 함수 - showToast
+export const showToast = (icon: SweetAlertIcon, firstLine: string, secondLine: string) => {
+  Toast.fire({
+    icon,
+    html: toastHtml(firstLine, secondLine),
+  });
 };
 
 // 일반 알림 함수 - alertSweet
-export const alertSweet = (icon: SweetAlertIcon, text: string, title: string) => {
+export const alertSweet = (icon: SweetAlertIcon, text: string) => {
   Swal.fire({
     icon,
     text,
-    title,
   });
 };


### PR DESCRIPTION
- 퀴즈 데이터 받아와서 퀴즈 푼 후 생명 감소 확인 완료
- Point 적용
- Toast 디자인 수정 (가운데 정렬)
- 영상 페이지 접근 차단 완료

퀴즈 데이터 잘 받아와지고 point는 유저 정보 API 내부에 있어서 아직 반영 되는 부분 확인 못하였습니다.

Toast: 디자인 구현하는데 `showToast('warning', '오늘 영상을 이미 시청하였어요.', '00시 이후에 다시 만나요!');` 파라미터 하나를 추가해서 줄바꿈 되도록 구현하였습니다.

영상 페이지: isWatched 가 true일 시 접근이 안 되도록 해놨었는데 적용이 안 돼서 일단 내려오는 response 메세지를 포함하면 차단하게끔 수정하였습니다.