### PR TITLE
fix: 폴라 아이디 수정 & 아이템 상세페이지 구매 전 잔여 포인트 수정

### DIFF
--- a/swype-client/src/components/CharacterCard.tsx
+++ b/swype-client/src/components/CharacterCard.tsx
@@ -6,6 +6,7 @@ type CharacterData = {
   isSelected: boolean;
   handleSelect: (item: string) => void;
   handleImage: (image: string) => void;
+  handleId: (id: number) => void;
 };
 
 interface ImgBoxProps {
@@ -17,6 +18,7 @@ const CharacterCard: React.FC<CharacterData> = ({
   isSelected,
   handleSelect,
   handleImage,
+  handleId,
 }) => {
   const handleCheck = () => {
     if (!Characters.isPossible) {
@@ -24,6 +26,7 @@ const CharacterCard: React.FC<CharacterData> = ({
       return;
     } else {
       handleSelect(Characters.name);
+      handleId(Characters.id);
     }
 
     !isSelected ? handleImage(Characters.image) : handleImage('');

--- a/swype-client/src/components/FeatureButtons.tsx
+++ b/swype-client/src/components/FeatureButtons.tsx
@@ -76,7 +76,6 @@ const Wrapper = styled.div`
   width:90%;
   height: 80%;
   padding:20px;
-  margin-bottom: 15px;
 `;
 
 const ButtonContainer = styled.div`
@@ -84,14 +83,15 @@ const ButtonContainer = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 80%;
+  height: 85%;
+  margin-top: 10px;
 `;
 
 const Info = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  height: 20%;
+  height: 15%;
 `;
 
 const LevelBox = styled.div`
@@ -107,13 +107,11 @@ const LevelBox = styled.div`
 const NameBox = styled.div`
   font-weight: ${props => props.theme.font.weight.extraBold};
   font-size: ${props => props.theme.font.size.buttonText};
-  
-
 `;
 
 const MovieBox = styled.div`
   width:50%;
-  height: 80%;
+  height: 85%;
   padding:30px;
   border-radius: 20px;
   background-color: #f5f5f5;
@@ -121,11 +119,9 @@ const MovieBox = styled.div`
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  cursor: pointer;
 `;
 
 const QuizBox = styled(MovieBox)`
-  cursor: pointer;
   margin-right: 10px;
 `;
 

--- a/swype-client/src/components/Modal/InfoModal.tsx
+++ b/swype-client/src/components/Modal/InfoModal.tsx
@@ -84,6 +84,7 @@ const InfoModal = () => {
   const navigate = useNavigate();
   const params = new URL(document.URL).searchParams;
   const character = params.get('character');
+  const characterId = params.get('id');
   const token = getCookie('Authorization');
 
   const { data: Description } = useQuery<DescriptionText>({
@@ -104,7 +105,7 @@ const InfoModal = () => {
     axios
       .post(
         `${import.meta.env.VITE_BASE_URL}/character/pick`,
-        { characterId: 2 },
+        { characterId },
         {
           headers: {
             Authorization: `${token}`,

--- a/swype-client/src/components/Modal/ItemModal.tsx
+++ b/swype-client/src/components/Modal/ItemModal.tsx
@@ -6,9 +6,6 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { userData } from '../../share/recoil/userAtom';
 import { FaArrowRightLong } from 'react-icons/fa6';
-import { BASE_URL } from '../../share/utils/OAuth';
-import axios from 'axios';
-import { getCookie } from '../../cookie';
 interface ItemModalProps {
   item?: DetailItem;
 }
@@ -16,35 +13,17 @@ interface ItemModalProps {
 const ItemModal: React.FC<ItemModalProps> = ({ item }) => {
   const user = useRecoilValue(userData);
   const navigate = useNavigate();
-  const token = getCookie('Authorization');
-
-  const buyItem = () => {
-    axios
-      .post(
-        `${BASE_URL}/item/buy`,
-        { itemId: item?.itemResponse.id },
-        {
-          headers: {
-            Authorization: `${token}`,
-          },
-        }
-      )
-      .then(res => {
-        console.log(res);
-        navigate('/store');
-      }).catch;
-  };
 
   return (
     <Container>
       <ModalBox>
         <InfoModal>
           <Title>
-            <text>{item?.itemResponse.name} 구매 완료</text>
+            <span>{item?.itemResponse.name} 구매 완료</span>
           </Title>
 
           <Info>
-            <text>{item?.itemResponse.description}</text>
+            <span>{item?.itemResponse.description}</span>
           </Info>
 
           <ImgBox>
@@ -55,9 +34,9 @@ const ItemModal: React.FC<ItemModalProps> = ({ item }) => {
           </ImgBox>
 
           <LevelBox>
-            <PointText>Lv.{item?.itemResponse.levelUp} </PointText>
+            <PointText>Lv.{Number(user?.level) - Number(item?.itemResponse.levelUp)} </PointText>
             <PointText>{<FaArrowRightLong />}</PointText>
-            <UpPointText>Lv.{Number(item?.itemResponse.levelUp) + Number(user?.level)}</UpPointText>
+            <UpPointText>Lv.{user?.level}</UpPointText>
           </LevelBox>
 
           <Button
@@ -65,7 +44,7 @@ const ItemModal: React.FC<ItemModalProps> = ({ item }) => {
             $textColor='white'
             width='100%'
             height='50px'
-            onClick={buyItem}
+            onClick={() => navigate('/store')}
           >
             확인
           </Button>
@@ -139,6 +118,5 @@ const PointText = styled.p`
 `;
 
 const UpPointText = styled(PointText)`
-    color: ${props => props.theme.colors.text.blue};
-   
+    color: ${props => props.theme.colors.text.blue}; 
 `;

--- a/swype-client/src/pages/Charcter.tsx
+++ b/swype-client/src/pages/Charcter.tsx
@@ -14,20 +14,16 @@ import { useNavigate } from 'react-router-dom';
 export default function Charcter() {
   const [selectedItem, setSelectedItem] = useState<string>('');
   const [selectImage, setSelectImage] = useState<string>('');
+  const [selectId, setSelectId] = useState<number>();
+
   const navigate = useNavigate();
-  // useEffect(() => {
-  //   try {
-  //     checkUser();
-  //     navigate('/');
-  //   } catch (err) {
-  //     console.log(err);
-  //   }
-  // }, []);
 
   const { data: Characters } = useQuery<CharacterList[]>({
     queryKey: ['Character'],
     queryFn: useGetCharacter,
   });
+
+  console.log(Characters);
 
   const handleSelect = (item: string) => {
     const newItem = item === selectedItem ? '' : item;
@@ -36,6 +32,10 @@ export default function Charcter() {
 
   const handleImage = (image: string) => {
     setSelectImage(image);
+  };
+
+  const handleId = (id: number) => {
+    setSelectId(id);
   };
 
   return (
@@ -61,6 +61,7 @@ export default function Charcter() {
                 isSelected={selectedItem === item.name}
                 handleSelect={handleSelect}
                 handleImage={handleImage}
+                handleId={handleId}
               />
             ))}
           </CardBox>
@@ -70,7 +71,7 @@ export default function Charcter() {
               width='90%'
               height='50px'
               $textColor='lightGray'
-              onClick={() => navigate(`/selected?character=${selectedItem}`)}
+              onClick={() => navigate(`/selected?character=${selectedItem}&id=${selectId}`)}
             >
               확인
             </Button>

--- a/swype-client/src/pages/Loading.tsx
+++ b/swype-client/src/pages/Loading.tsx
@@ -14,14 +14,17 @@ const Loading = () => {
   const useremail = params.get('useremail');
   const navigate = useNavigate();
 
-  const { data: userInfo } = useQuery({
+  const { data: userInfo, error } = useQuery({
     queryKey: ['userInfo'],
     queryFn: getUserInfo,
+    retry: 1,
   });
 
   if (userInfo?.character.id) {
     navigate('/stage');
-  } else {
+  }
+
+  if (error) {
     navigate('/character');
   }
 

--- a/swype-client/src/pages/Stage.tsx
+++ b/swype-client/src/pages/Stage.tsx
@@ -134,12 +134,11 @@ const CharacterBox = styled.div`
   align-items: center;
   justify-content: flex-end;
   width: 100%;
-  height: 40%;
+  height: 70%;
 `;
 
 const CharacterImage = styled.img`
   width: 85%;
-  height: 100%;
   height: auto;
 `;
 
@@ -149,9 +148,8 @@ const ButtonWrapper = styled.div`
   justify-content: center;
   flex-direction: column;
   width: 100%;
-  height: auto;
+  position: absolute;
   margin-top: 70px;
-  height: 20%;
   span{
     font-weight: ${props => props.theme.font.weight.extraBold};
     font-size: ${props => props.theme.font.size.choose};
@@ -186,8 +184,8 @@ const TrashButton = styled(StoreButton)`
 
 const InfoBox = styled.div`
   width:100%;
-  height: 40%;
+  height: 35%;
   display: flex;
   justify-content: center;
-  align-items: flex-end;
+  align-items: center;
 `;

--- a/swype-client/src/pages/store/StoreDetail.tsx
+++ b/swype-client/src/pages/store/StoreDetail.tsx
@@ -6,13 +6,17 @@ import Button from '../../components/common/Button';
 import Point from '../../components/Point';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDetailItems } from '../../share/queries/useDetailItem';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { DetailItem } from '../../model/storeType';
 import { useState } from 'react';
 import ItemModal from '../../components/Modal/ItemModal';
+import { useBuyItem } from '../../share/queries/useBuyItem';
+import { userData } from '../../share/recoil/userAtom';
+import { useSetRecoilState } from 'recoil';
 
 export default function StoreDetail() {
   const [isModal, setIsModal] = useState(false);
+  const setUserdata = useSetRecoilState(userData);
   const navigate = useNavigate();
   const { id } = useParams();
 
@@ -22,6 +26,17 @@ export default function StoreDetail() {
   });
 
   const Calnum = (item?.userPoint ?? 0) - (item?.itemResponse?.price ?? 0);
+
+  const BuyItem = useMutation({
+    mutationFn: useBuyItem,
+    onSuccess: data => {
+      setIsModal(true);
+      setUserdata(prev => ({
+        ...prev,
+        level: prev.level + data.levelUp,
+      }));
+    },
+  });
 
   return (
     <>
@@ -89,7 +104,7 @@ export default function StoreDetail() {
               $textColor='lightGray'
               width='45%'
               height='50px'
-              onClick={() => setIsModal(true)}
+              onClick={() => BuyItem.mutate(item?.itemResponse.id)}
             >
               구매하기
             </Button>

--- a/swype-client/src/share/queries/useBuyItem.ts
+++ b/swype-client/src/share/queries/useBuyItem.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import { BASE_URL } from '../utils/OAuth';
+import { showToast } from '../utils/Toast';
+import { getCookie } from '../../cookie';
+
+const token = getCookie('Authorization');
+export const useBuyItem = (itemId?: number) => {
+  return axios
+    .post(
+      `${BASE_URL}/item/buy`,
+      { itemId },
+      {
+        headers: {
+          Authorization: `${token}`,
+        },
+      }
+    )
+    .then(res => {
+      return res.data.data.itemResponse;
+    })
+    .catch(error => {
+      showToast('warning', '구매하는데 오류가 발생했습니다.', '');
+      return Promise.reject(error);
+    });
+};

--- a/swype-client/src/share/recoil/userAtom.tsx
+++ b/swype-client/src/share/recoil/userAtom.tsx
@@ -1,7 +1,22 @@
 import { atom } from 'recoil';
 import { UserInfo } from '../../model/userInfoType';
 
-export const userData = atom<UserInfo | null>({
+// UserInfo의 기본값을 정의합니다.
+const defaultUserInfo: UserInfo = {
+  character: {
+    id: 0,
+    name: '',
+    maxLevel: 0,
+  },
+  level: 0,
+  environment: '',
+  backgroundImage: '',
+  characterImage: '',
+  userPoint: 0,
+};
+
+// Recoil atom 정의
+export const userData = atom<UserInfo>({
   key: 'userData',
-  default: null,
+  default: defaultUserInfo,
 });


### PR DESCRIPTION
- 폴라 아이디 다른 캐릭터도 열릴 가능성 생각해서 동적으로 적용되게 수정
- 아이템 상세페이지 포인트 -100 > 구매 불가로 UI 변경
- 상점 페이지에서 아이템 구매 > 아이템 메인 > 다시 구매 했을 때 모달 레벨 바로 변경 안되는 부분 수정
- 스테이지 페이지에서 성장한 폴라있어도 스크롤 안되게 UI 구성 다시 수정 완료
![image](https://github.com/user-attachments/assets/003eebec-99df-4ff8-b274-945409021251)
